### PR TITLE
EVA-1280  Store declustering as update events in history tracking

### DIFF
--- a/accession-commons-core/src/main/java/uk/ac/ebi/ampt2d/commons/accession/persistence/services/BasicSpringDataRepositoryDatabaseService.java
+++ b/accession-commons-core/src/main/java/uk/ac/ebi/ampt2d/commons/accession/persistence/services/BasicSpringDataRepositoryDatabaseService.java
@@ -204,6 +204,13 @@ public class BasicSpringDataRepositoryDatabaseService<
             throw new HashAlreadyExistsException(dbAccession.getHashedMessage(), dbAccession.getAccession());
         }
     }
+    private void checkHashDoesNotExistWithAccessionDifferentThan(String hash, ACCESSION accession)
+            throws HashAlreadyExistsException {
+        final ACCESSION_ENTITY dbAccession = repository.findOne(hash);
+        if (dbAccession != null && dbAccession.getAccession() != accession) {
+            throw new HashAlreadyExistsException(dbAccession.getHashedMessage(), dbAccession.getAccession());
+        }
+    }
 
     /**
      * @param accessionId
@@ -223,7 +230,7 @@ public class BasicSpringDataRepositoryDatabaseService<
             throws AccessionDoesNotExistException, HashAlreadyExistsException, AccessionMergedException,
             AccessionDeprecatedException {
         ACCESSION_ENTITY oldVersion = doFindAccessionVersion(accession, version);
-        checkHashDoesNotExist(hash);
+        checkHashDoesNotExistWithAccessionDifferentThan(hash, oldVersion.getAccession());
 
         inactiveAccessionService.update(oldVersion, "Version update");
         repository.delete(oldVersion);

--- a/accession-commons-core/src/main/java/uk/ac/ebi/ampt2d/commons/accession/persistence/services/BasicSpringDataRepositoryDatabaseService.java
+++ b/accession-commons-core/src/main/java/uk/ac/ebi/ampt2d/commons/accession/persistence/services/BasicSpringDataRepositoryDatabaseService.java
@@ -204,13 +204,6 @@ public class BasicSpringDataRepositoryDatabaseService<
             throw new HashAlreadyExistsException(dbAccession.getHashedMessage(), dbAccession.getAccession());
         }
     }
-    private void checkHashDoesNotExistWithAccessionDifferentThan(String hash, ACCESSION accession)
-            throws HashAlreadyExistsException {
-        final ACCESSION_ENTITY dbAccession = repository.findOne(hash);
-        if (dbAccession != null && dbAccession.getAccession() != accession) {
-            throw new HashAlreadyExistsException(dbAccession.getHashedMessage(), dbAccession.getAccession());
-        }
-    }
 
     /**
      * @param accessionId
@@ -230,8 +223,9 @@ public class BasicSpringDataRepositoryDatabaseService<
             throws AccessionDoesNotExistException, HashAlreadyExistsException, AccessionMergedException,
             AccessionDeprecatedException {
         ACCESSION_ENTITY oldVersion = doFindAccessionVersion(accession, version);
-        checkHashDoesNotExistWithAccessionDifferentThan(hash, oldVersion.getAccession());
-
+        if (!oldVersion.getHashedMessage().equals(hash)) {
+            checkHashDoesNotExist(hash);
+        }
         inactiveAccessionService.update(oldVersion, "Version update");
         repository.delete(oldVersion);
         checkedInsert(accession, hash, model, version);

--- a/accession-commons-jpa/src/test/java/uk/ac/ebi/ampt2d/commons/accession/persistence/jpa/repositories/BaseJpaAccessionedObjectRepositoryTest.java
+++ b/accession-commons-jpa/src/test/java/uk/ac/ebi/ampt2d/commons/accession/persistence/jpa/repositories/BaseJpaAccessionedObjectRepositoryTest.java
@@ -63,15 +63,15 @@ public class BaseJpaAccessionedObjectRepositoryTest {
 
     @Test
     public void testInsertTwoVersionsSameAccession() {
-        TestEntity testEntity1 = new TestEntity("a1", "h1", 1, "something1");
-        TestEntity testEntity2 = new TestEntity("a1", "h2", 2, "something2");
+        TestEntity testEntity1 = new TestEntity("a1", "h1", 1, "something1", "");
+        TestEntity testEntity2 = new TestEntity("a1", "h2", 2, "something2", "");
         repository.insert(Arrays.asList(testEntity1, testEntity2));
     }
 
     @Test
     public void testFindByAccession() {
-        TestEntity testEntity1 = new TestEntity("a1", "h1", 1, "something1");
-        TestEntity testEntity2 = new TestEntity("a1", "h2", 2, "something2");
+        TestEntity testEntity1 = new TestEntity("a1", "h1", 1, "something1", "");
+        TestEntity testEntity2 = new TestEntity("a1", "h2", 2, "something2", "");
         repository.insert(Arrays.asList(testEntity1, testEntity2));
         assertEquals(2, repository.findByAccession("a1").size());
         assertEquals(2, repository.findByAccessionIn(Arrays.asList("a1")).size());
@@ -79,8 +79,8 @@ public class BaseJpaAccessionedObjectRepositoryTest {
 
     @Test
     public void testFindByAccessionAndVersion() {
-        TestEntity testEntity1 = new TestEntity("a1", "h1", 1, "something1");
-        TestEntity testEntity2 = new TestEntity("a1", "h2", 2, "something2");
+        TestEntity testEntity1 = new TestEntity("a1", "h1", 1, "something1", "");
+        TestEntity testEntity2 = new TestEntity("a1", "h2", 2, "something2", "");
         repository.insert(Arrays.asList(testEntity1, testEntity2));
         assertEquals("something1", repository.findByAccessionAndVersion("a1", 1).getValue());
         assertEquals("something2", repository.findByAccessionAndVersion("a1", 2).getValue());

--- a/accession-commons-jpa/src/test/java/uk/ac/ebi/ampt2d/commons/accession/persistence/jpa/services/JpaBasicSpringDataRepositoryDatabaseServiceTest.java
+++ b/accession-commons-jpa/src/test/java/uk/ac/ebi/ampt2d/commons/accession/persistence/jpa/services/JpaBasicSpringDataRepositoryDatabaseServiceTest.java
@@ -168,24 +168,20 @@ public class JpaBasicSpringDataRepositoryDatabaseServiceTest {
     @Test(expected = HashAlreadyExistsException.class)
     public void updateWithExistingObjectFails() throws AccessionDoesNotExistException,
             HashAlreadyExistsException, AccessionDeprecatedException, AccessionMergedException {
-        service.save(Arrays.asList(new AccessionWrapper<>("a2", "h1", TestModel.of("something2"))));
-        service.update("a2", "h1", TestModel.of("something2"), 1);
-    }
-    
-    @Test(expected = HashAlreadyExistsException.class)
-    public void updateWithExistingObjectFails_() throws AccessionDoesNotExistException,
-            HashAlreadyExistsException, AccessionDeprecatedException, AccessionMergedException {
         service.save(Arrays.asList(new AccessionWrapper<>("a1", "h1", TestModel.of("something1"))));
         service.save(Arrays.asList(new AccessionWrapper<>("a2", "h2", TestModel.of("something2"))));
         service.update("a1", "h2", TestModel.of("something2"), 1);
     }
 
-//    @Test(expected = HashAlreadyExistsException.class)
-//    public void updateNonIdentifyingField() throws AccessionDoesNotExistException,
-//            HashAlreadyExistsException, AccessionDeprecatedException, AccessionMergedException {
-//        service.save(Arrays.asList(new AccessionWrapper<>("a2", "h1", TestModel.of("something2", "nonIdentifying 1"))));
-//        service.update("a2", "h1", TestModel.of("something2"), 1);
-//    }
+    @Test
+    public void updateNonIdentifyingField() throws AccessionDoesNotExistException,
+            HashAlreadyExistsException, AccessionDeprecatedException, AccessionMergedException {
+        service.save(Arrays.asList(new AccessionWrapper<>("a2", "h1", TestModel.of("something2", "nonIdentifying 1"))));
+        AccessionVersionsWrapper<TestModel, String, String> update = service.update(
+                "a2", "h1", TestModel.of("something2", "nonIdentifying 2"), 1);
+        assertEquals(1, update.getModelWrappers().size());
+        assertEquals("nonIdentifying 2", update.getModelWrappers().get(0).getData().getNonIdentifyingValue());
+    }
 
     @Test
     public void updateDoesNotCreateNewVersion() throws AccessionDoesNotExistException,

--- a/accession-commons-jpa/src/test/java/uk/ac/ebi/ampt2d/commons/accession/persistence/jpa/services/JpaBasicSpringDataRepositoryDatabaseServiceTest.java
+++ b/accession-commons-jpa/src/test/java/uk/ac/ebi/ampt2d/commons/accession/persistence/jpa/services/JpaBasicSpringDataRepositoryDatabaseServiceTest.java
@@ -171,6 +171,21 @@ public class JpaBasicSpringDataRepositoryDatabaseServiceTest {
         service.save(Arrays.asList(new AccessionWrapper<>("a2", "h1", TestModel.of("something2"))));
         service.update("a2", "h1", TestModel.of("something2"), 1);
     }
+    
+    @Test(expected = HashAlreadyExistsException.class)
+    public void updateWithExistingObjectFails_() throws AccessionDoesNotExistException,
+            HashAlreadyExistsException, AccessionDeprecatedException, AccessionMergedException {
+        service.save(Arrays.asList(new AccessionWrapper<>("a1", "h1", TestModel.of("something1"))));
+        service.save(Arrays.asList(new AccessionWrapper<>("a2", "h2", TestModel.of("something2"))));
+        service.update("a1", "h2", TestModel.of("something2"), 1);
+    }
+
+//    @Test(expected = HashAlreadyExistsException.class)
+//    public void updateNonIdentifyingField() throws AccessionDoesNotExistException,
+//            HashAlreadyExistsException, AccessionDeprecatedException, AccessionMergedException {
+//        service.save(Arrays.asList(new AccessionWrapper<>("a2", "h1", TestModel.of("something2", "nonIdentifying 1"))));
+//        service.update("a2", "h1", TestModel.of("something2"), 1);
+//    }
 
     @Test
     public void updateDoesNotCreateNewVersion() throws AccessionDoesNotExistException,

--- a/accession-commons-jpa/src/test/java/uk/ac/ebi/ampt2d/test/persistence/TestEntity.java
+++ b/accession-commons-jpa/src/test/java/uk/ac/ebi/ampt2d/test/persistence/TestEntity.java
@@ -28,22 +28,31 @@ public class TestEntity extends AccessionedEntity<TestModel, String> implements 
 
     private String something;
 
+    private String nonIdentifyingValue;
+
     TestEntity() {
         super(null, null, 1);
     }
 
     public TestEntity(AccessionWrapper<TestModel, String, String> model) {
-        this(model.getAccession(), model.getHash(), model.getVersion(), model.getData().getValue());
+        this(model.getAccession(), model.getHash(), model.getVersion(), model.getData().getValue(), "");
     }
 
-    public TestEntity(String accession, String hashedMessage, int version, String something) {
+    public TestEntity(String accession, String hashedMessage, int version, String something,
+                      String nonIdentifyingValue) {
         super(hashedMessage, accession, version);
         this.something = something;
+        this.nonIdentifyingValue = nonIdentifyingValue;
     }
 
     @Override
     public String getValue() {
         return something;
+    }
+
+    @Override
+    public String getNonIdentifyingValue() {
+        return nonIdentifyingValue;
     }
 
     @Override

--- a/accession-commons-jpa/src/test/java/uk/ac/ebi/ampt2d/test/persistence/TestEntity.java
+++ b/accession-commons-jpa/src/test/java/uk/ac/ebi/ampt2d/test/persistence/TestEntity.java
@@ -35,7 +35,8 @@ public class TestEntity extends AccessionedEntity<TestModel, String> implements 
     }
 
     public TestEntity(AccessionWrapper<TestModel, String, String> model) {
-        this(model.getAccession(), model.getHash(), model.getVersion(), model.getData().getValue(), "");
+        this(model.getAccession(), model.getHash(), model.getVersion(), model.getData().getValue(),
+             model.getData().getNonIdentifyingValue());
     }
 
     public TestEntity(String accession, String hashedMessage, int version, String something,

--- a/accession-commons-jpa/src/test/java/uk/ac/ebi/ampt2d/test/persistence/TestInactiveAccessionEntity.java
+++ b/accession-commons-jpa/src/test/java/uk/ac/ebi/ampt2d/test/persistence/TestInactiveAccessionEntity.java
@@ -28,6 +28,8 @@ public class TestInactiveAccessionEntity extends InactiveAccessionEntity<TestMod
 
     private String something;
 
+    private String nonIdentifyingValue;
+
     TestInactiveAccessionEntity() {
         super();
     }
@@ -35,10 +37,17 @@ public class TestInactiveAccessionEntity extends InactiveAccessionEntity<TestMod
     public TestInactiveAccessionEntity(TestEntity testEntity) {
         super(testEntity);
         this.something = testEntity.getValue();
+        this.nonIdentifyingValue = testEntity.getNonIdentifyingValue();
     }
 
+    @Override
     public String getValue() {
         return something;
+    }
+
+    @Override
+    public String getNonIdentifyingValue() {
+        return nonIdentifyingValue;
     }
 
     @Override

--- a/accession-commons-mongodb/src/test/java/uk/ac/ebi/ampt2d/test/persistence/document/TestDocument.java
+++ b/accession-commons-mongodb/src/test/java/uk/ac/ebi/ampt2d/test/persistence/document/TestDocument.java
@@ -27,6 +27,8 @@ public class TestDocument extends AccessionedDocument<TestModel, String> impleme
 
     private String value;
 
+    private String nonIdentifyingValue;
+
     TestDocument() {
         super();
     }
@@ -34,20 +36,32 @@ public class TestDocument extends AccessionedDocument<TestModel, String> impleme
     public TestDocument(String value, String hashedMessage, String accession) {
         super(hashedMessage, accession);
         this.value = value;
+        this.nonIdentifyingValue = "";
     }
 
     public TestDocument(String value, String hashedMessage, String accession, int version) {
+        this(value, "", hashedMessage, accession, version);
+    }
+
+    public TestDocument(String value, String nonIdentifyingValue, String hashedMessage, String accession, int version) {
         super(hashedMessage, accession, version);
         this.value = value;
+        this.nonIdentifyingValue = nonIdentifyingValue;
     }
 
     public TestDocument(AccessionWrapper<TestModel, String, String> wrapper) {
-        this(wrapper.getData().getValue(), wrapper.getHash(), wrapper.getAccession(), wrapper.getVersion());
+        this(wrapper.getData().getValue(), wrapper.getData().getNonIdentifyingValue(), wrapper.getHash(),
+             wrapper.getAccession(), wrapper.getVersion());
     }
 
     @Override
     public String getValue() {
         return value;
+    }
+
+    @Override
+    public String getNonIdentifyingValue() {
+        return nonIdentifyingValue;
     }
 
     public static TestDocument document(int num) {

--- a/accession-commons-mongodb/src/test/java/uk/ac/ebi/ampt2d/test/persistence/document/TestInactiveSubDocument.java
+++ b/accession-commons-mongodb/src/test/java/uk/ac/ebi/ampt2d/test/persistence/document/TestInactiveSubDocument.java
@@ -24,6 +24,8 @@ public class TestInactiveSubDocument extends InactiveSubDocument<TestModel, Stri
 
     private String value;
 
+    private String nonIdentifyingValue;
+
     TestInactiveSubDocument() {
         super();
     }
@@ -31,11 +33,17 @@ public class TestInactiveSubDocument extends InactiveSubDocument<TestModel, Stri
     public TestInactiveSubDocument(TestDocument testDocument) {
         super(testDocument);
         this.value = testDocument.getValue();
+        this.nonIdentifyingValue = testDocument.getNonIdentifyingValue();
     }
 
     @Override
     public String getValue() {
         return value;
+    }
+
+    @Override
+    public String getNonIdentifyingValue() {
+        return nonIdentifyingValue;
     }
 
     @Override

--- a/accession-commons-monotonic-generator-jpa/src/test/java/uk/ac/ebi/ampt2d/test/persistence/TestMonotonicEntity.java
+++ b/accession-commons-monotonic-generator-jpa/src/test/java/uk/ac/ebi/ampt2d/test/persistence/TestMonotonicEntity.java
@@ -28,6 +28,8 @@ public class TestMonotonicEntity extends AccessionedEntity<TestModel, Long> impl
 
     private String something;
 
+    private String nonIdentifyingValue;
+
     TestMonotonicEntity() {
         super(null, null, 1);
     }
@@ -38,13 +40,24 @@ public class TestMonotonicEntity extends AccessionedEntity<TestModel, Long> impl
     }
 
     public TestMonotonicEntity(Long accession, String hashedMessage, int version, String something) {
+        this(accession, hashedMessage, version, something, "");
+    }
+
+    public TestMonotonicEntity(Long accession, String hashedMessage, int version, String something,
+                               String nonIdentifyingValue) {
         super(hashedMessage, accession, version);
         this.something = something;
+        this.nonIdentifyingValue = nonIdentifyingValue;
     }
 
     @Override
     public String getValue() {
         return something;
+    }
+
+    @Override
+    public String getNonIdentifyingValue() {
+        return nonIdentifyingValue;
     }
 
     @Override

--- a/accession-commons-monotonic-generator-jpa/src/test/java/uk/ac/ebi/ampt2d/test/persistence/TestMonotonicInactiveAccessionEntity.java
+++ b/accession-commons-monotonic-generator-jpa/src/test/java/uk/ac/ebi/ampt2d/test/persistence/TestMonotonicInactiveAccessionEntity.java
@@ -27,6 +27,8 @@ public class TestMonotonicInactiveAccessionEntity extends InactiveAccessionEntit
 
     private String something;
 
+    private String nonIdentifyingValue;
+
     TestMonotonicInactiveAccessionEntity() {
         super();
     }
@@ -34,6 +36,7 @@ public class TestMonotonicInactiveAccessionEntity extends InactiveAccessionEntit
     public TestMonotonicInactiveAccessionEntity(TestMonotonicEntity testEntity) {
         super(testEntity);
         this.something = testEntity.getValue();
+        this.nonIdentifyingValue = testEntity.getNonIdentifyingValue();
     }
 
     @Override
@@ -44,5 +47,10 @@ public class TestMonotonicInactiveAccessionEntity extends InactiveAccessionEntit
     @Override
     public String getValue() {
         return something;
+    }
+
+    @Override
+    public String getNonIdentifyingValue() {
+        return nonIdentifyingValue;
     }
 }

--- a/accession-commons-test/src/main/java/uk/ac/ebi/ampt2d/test/models/TestModel.java
+++ b/accession-commons-test/src/main/java/uk/ac/ebi/ampt2d/test/models/TestModel.java
@@ -21,8 +21,34 @@ public interface TestModel {
 
     String getValue();
 
+    String getNonIdentifyingValue();
+
     static TestModel of(String value) {
-        return () -> value;
+        return new TestModel() {
+            @Override
+            public String getValue() {
+                return value;
+            }
+
+            @Override
+            public String getNonIdentifyingValue() {
+                return "";
+            }
+        };
     }
 
+//    static TestModel of(String value, String nonIdentifyingValue) {
+//        return new TestModel() {
+//            @Override
+//            public String getValue() {
+//                return value;
+//            }
+//
+//            @Override
+//            public String getNonIdentifyingValue() {
+//                return nonIdentifyingValue;
+//            }
+//        };
+//    }
+//
 }

--- a/accession-commons-test/src/main/java/uk/ac/ebi/ampt2d/test/models/TestModel.java
+++ b/accession-commons-test/src/main/java/uk/ac/ebi/ampt2d/test/models/TestModel.java
@@ -37,18 +37,18 @@ public interface TestModel {
         };
     }
 
-//    static TestModel of(String value, String nonIdentifyingValue) {
-//        return new TestModel() {
-//            @Override
-//            public String getValue() {
-//                return value;
-//            }
-//
-//            @Override
-//            public String getNonIdentifyingValue() {
-//                return nonIdentifyingValue;
-//            }
-//        };
-//    }
-//
+    static TestModel of(String value, String nonIdentifyingValue) {
+        return new TestModel() {
+            @Override
+            public String getValue() {
+                return value;
+            }
+
+            @Override
+            public String getNonIdentifyingValue() {
+                return nonIdentifyingValue;
+            }
+        };
+    }
+
 }

--- a/accession-commons-test/src/main/java/uk/ac/ebi/ampt2d/test/rest/BasicRestModel.java
+++ b/accession-commons-test/src/main/java/uk/ac/ebi/ampt2d/test/rest/BasicRestModel.java
@@ -26,6 +26,8 @@ public class BasicRestModel implements TestModel {
     @NotNull(message = "Please provide a value")
     private String value;
 
+    private String nonIdentifyingValue;
+
     public BasicRestModel() {
     }
 
@@ -33,9 +35,18 @@ public class BasicRestModel implements TestModel {
         this.value = value;
     }
 
+    public BasicRestModel(String value, String nonIdentifyingValue) {
+        this.value = value;
+        this.nonIdentifyingValue = nonIdentifyingValue;
+    }
+
     @Override
     public String getValue() {
         return value;
     }
 
+    @Override
+    public String getNonIdentifyingValue() {
+        return nonIdentifyingValue;
+    }
 }


### PR DESCRIPTION
For EVA we need the `update` method to work if you modify a non-identifying field of the accessioned object. That is, allow an update making a hash collision, only in the case that the collision is with the object that will be removed, so the collsion won't occur. 