### PR TITLE
EVA-1851 - Allow block allocation to recover from constraint violations

### DIFF
--- a/accession-commons-core/src/main/java/uk/ac/ebi/ampt2d/commons/accession/utils/ExponentialBackOff.java
+++ b/accession-commons-core/src/main/java/uk/ac/ebi/ampt2d/commons/accession/utils/ExponentialBackOff.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.ac.ebi.ampt2d.commons.accession.utils.exceptions.ExponentialBackOffMaxRetriesRuntimeException;
 
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
 
 /**
@@ -32,6 +33,8 @@ public abstract class ExponentialBackOff {
 
     static int DEFAULT_TOTAL_ATTEMPTS = 7;
     private static int DEFAULT_TIME_BASE = 1000;
+    private static int MAX_JITTER = 1000;
+    private static int MIN_JITTER = 100;
 
     public static void execute(Runnable function) {
         execute(function, DEFAULT_TOTAL_ATTEMPTS, DEFAULT_TIME_BASE);
@@ -78,7 +81,8 @@ public abstract class ExponentialBackOff {
 
     private static void doWait(int valueInTheSeries, int timeBase) {
         try {
-            Thread.sleep(valueInTheSeries * timeBase);
+            Thread.sleep(valueInTheSeries * timeBase +
+                                 ThreadLocalRandom.current().nextInt(MIN_JITTER, MAX_JITTER));
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }

--- a/accession-commons-monotonic-generator-jpa/src/main/java/uk/ac/ebi/ampt2d/commons/accession/persistence/jpa/monotonic/service/ContiguousIdBlockService.java
+++ b/accession-commons-monotonic-generator-jpa/src/main/java/uk/ac/ebi/ampt2d/commons/accession/persistence/jpa/monotonic/service/ContiguousIdBlockService.java
@@ -51,10 +51,12 @@ public class ContiguousIdBlockService {
         BlockParameters blockParameters = getBlockParameters(categoryId);
         if (lastBlock != null) {
             return repository.save(lastBlock.nextBlock(instanceId, blockParameters.getBlockSize(),
-                    blockParameters.getNextBlockInterval(), blockParameters.getBlockStartValue()));
+                                                       blockParameters.getNextBlockInterval(),
+                                                       blockParameters.getBlockStartValue()));
         } else {
             ContiguousIdBlock newBlock = new ContiguousIdBlock(categoryId, instanceId,
-                    blockParameters.getBlockStartValue(), blockParameters.getBlockSize());
+                                                               blockParameters.getBlockStartValue(),
+                                                               blockParameters.getBlockSize());
             return repository.save(newBlock);
         }
     }


### PR DESCRIPTION
After some experimenting with concurrent runs of the accessioning pipeline across multiple machines, I discovered that the exponential backoff  **without any random jitter** causes the concurrent instances to attempt the block allocation at the same intervals. Staggering this backoff with a random jitter (ExponentialBackoff.java) allows competing instances to properly secure the resources required for block allocation.  