### PR TITLE
EVA-1984 - Use MongoDB 4.0 in Travis to run tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jdk:
   - openjdk8
 
 env:
-  - MONGODB_VERSION=3.2.17
+  - MONGODB_VERSION=4.0.18
 
 install:
   - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-$MONGODB_VERSION.tgz


### PR DESCRIPTION
@andresfsilva Meant to do this while upgrading accession-commons but missed it. So here it is...