### PR TITLE
EVA-2070 Add created date setter to EventDocument

### DIFF
--- a/accession-commons-mongodb/src/main/java/uk/ac/ebi/ampt2d/commons/accession/persistence/mongodb/document/EventDocument.java
+++ b/accession-commons-mongodb/src/main/java/uk/ac/ebi/ampt2d/commons/accession/persistence/mongodb/document/EventDocument.java
@@ -100,6 +100,14 @@ public abstract class EventDocument<
         return createdDate;
     }
 
+    /**
+     * When performing bulk operations the createdDate will not be filled automatically, so the setter is needed
+     * in order to assign the date manually
+     */
+    public void setCreatedDate(LocalDateTime createdDate) {
+        this.createdDate = createdDate;
+    }
+
     @Override
     public String getId() {
         return id;

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.20.1</version>
                 <configuration>
                     <reuseForks>false</reuseForks>
                 </configuration>


### PR DESCRIPTION
When performing bulk operation the audit field `createdDate` is not automatically filled so it has to be manually set so the setter is needed.