### PR TITLE
EVA- 2675 Change block allocation strategy

### DIFF
--- a/accession-commons-monotonic-generator-jpa/src/main/java/uk/ac/ebi/ampt2d/commons/accession/generators/monotonic/MonotonicAccessionGenerator.java
+++ b/accession-commons-monotonic-generator-jpa/src/main/java/uk/ac/ebi/ampt2d/commons/accession/generators/monotonic/MonotonicAccessionGenerator.java
@@ -27,7 +27,6 @@ import uk.ac.ebi.ampt2d.commons.accession.persistence.jpa.monotonic.entities.Con
 import uk.ac.ebi.ampt2d.commons.accession.persistence.jpa.monotonic.service.ContiguousIdBlockService;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.jpa.monotonic.service.MonotonicDatabaseService;
 import uk.ac.ebi.ampt2d.commons.accession.utils.ExponentialBackOff;
-import uk.ac.ebi.ampt2d.commons.accession.utils.exceptions.ExponentialBackOffMaxRetriesRuntimeException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -85,6 +84,7 @@ public class MonotonicAccessionGenerator<MODEL> implements AccessionGenerator<MO
         //Insert as available ranges
         for (ContiguousIdBlock block : uncompletedBlocks) {
             blockManager.addBlock(block);
+            blockService.markBlockAsUsed(block);
         }
         return blockManager;
     }
@@ -135,7 +135,7 @@ public class MonotonicAccessionGenerator<MODEL> implements AccessionGenerator<MO
     }
 
     private synchronized void reserveNewBlock(String categoryId, String instanceId) {
-        blockManager.addBlock(blockService.reserveNewBlock(categoryId, instanceId));
+        blockManager.addNewBlock(blockService.reserveNewBlock(categoryId, instanceId));
     }
 
     public synchronized void commit(long... accessions) throws AccessionIsNotPendingException {

--- a/accession-commons-monotonic-generator-jpa/src/main/java/uk/ac/ebi/ampt2d/commons/accession/persistence/jpa/monotonic/entities/ContiguousIdBlock.java
+++ b/accession-commons-monotonic-generator-jpa/src/main/java/uk/ac/ebi/ampt2d/commons/accession/persistence/jpa/monotonic/entities/ContiguousIdBlock.java
@@ -75,7 +75,6 @@ public class ContiguousIdBlock implements Comparable<ContiguousIdBlock> {
         this.firstValue = firstValue;
         this.lastValue = firstValue + size - 1;
         this.lastCommitted = firstValue + size - 1;
-//        this.lastCommitted = firstValue - 1;
     }
 
     /**

--- a/accession-commons-monotonic-generator-jpa/src/main/java/uk/ac/ebi/ampt2d/commons/accession/persistence/jpa/monotonic/entities/ContiguousIdBlock.java
+++ b/accession-commons-monotonic-generator-jpa/src/main/java/uk/ac/ebi/ampt2d/commons/accession/persistence/jpa/monotonic/entities/ContiguousIdBlock.java
@@ -74,7 +74,8 @@ public class ContiguousIdBlock implements Comparable<ContiguousIdBlock> {
         this.applicationInstanceId = applicationInstanceId;
         this.firstValue = firstValue;
         this.lastValue = firstValue + size - 1;
-        this.lastCommitted = firstValue - 1;
+        this.lastCommitted = firstValue + size - 1;
+//        this.lastCommitted = firstValue - 1;
     }
 
     /**

--- a/accession-commons-monotonic-generator-jpa/src/main/java/uk/ac/ebi/ampt2d/commons/accession/persistence/jpa/monotonic/service/ContiguousIdBlockService.java
+++ b/accession-commons-monotonic-generator-jpa/src/main/java/uk/ac/ebi/ampt2d/commons/accession/persistence/jpa/monotonic/service/ContiguousIdBlockService.java
@@ -69,6 +69,18 @@ public class ContiguousIdBlockService {
         return reservedBlock;
     }
 
+    /**
+     * Mark the block as completely used in the contiguous_id_blocks tables but in the block manager keep last_committed
+     * value before the beginning of the block
+     */
+    @Transactional(isolation = Isolation.SERIALIZABLE)
+    public void markBlockAsUsed(ContiguousIdBlock block) {
+        long lastCommitted = block.getLastCommitted();
+        block.setLastCommitted(block.getLastValue());
+        repository.save(block);
+        block.setLastCommitted(lastCommitted);
+    }
+
     public BlockParameters getBlockParameters(String categoryId) {
         return categoryBlockInitializations.get(categoryId);
     }

--- a/accession-commons-monotonic-generator-jpa/src/test/java/uk/ac/ebi/ampt2d/commons/accession/core/BasicMonotonicAccessioningWithAlternateRangesTest.java
+++ b/accession-commons-monotonic-generator-jpa/src/test/java/uk/ac/ebi/ampt2d/commons/accession/core/BasicMonotonicAccessioningWithAlternateRangesTest.java
@@ -75,6 +75,7 @@ public class BasicMonotonicAccessioningWithAlternateRangesTest {
         assertEquals(0, evaAccessions.get(0).getAccession().longValue());
         assertEquals(8, evaAccessions.get(8).getAccession().longValue());
         //BlockSize of 10 was reserved but only 9 elements have been accessioned
+        //All accessions were marked as used
         assertEquals(1, contiguousIdBlockService
                 .getUncompletedBlocksByCategoryIdAndApplicationInstanceIdOrderByEndAsc(categoryId, INSTANCE_ID)
                 .size());

--- a/accession-commons-monotonic-generator-jpa/src/test/java/uk/ac/ebi/ampt2d/commons/accession/generators/monotonic/BlockManagerTest.java
+++ b/accession-commons-monotonic-generator-jpa/src/test/java/uk/ac/ebi/ampt2d/commons/accession/generators/monotonic/BlockManagerTest.java
@@ -22,6 +22,10 @@ import uk.ac.ebi.ampt2d.commons.accession.core.exceptions.AccessionCouldNotBeGen
 import uk.ac.ebi.ampt2d.commons.accession.core.exceptions.AccessionIsNotPendingException;
 import uk.ac.ebi.ampt2d.commons.accession.persistence.jpa.monotonic.entities.ContiguousIdBlock;
 
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Set;
+
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -41,7 +45,7 @@ public class BlockManagerTest {
     @Test
     public void availableAccessionWhenBlockHashBeenAdded() {
         BlockManager manager = new BlockManager();
-        manager.addBlock(new ContiguousIdBlock(CATEGORY_ID, INSTANCE_ID, 0, 100));
+        manager.addNewBlock(new ContiguousIdBlock(CATEGORY_ID, INSTANCE_ID, 0, 100));
         assertTrue(manager.hasAvailableAccessions(10));
         assertFalse(manager.hasAvailableAccessions(101));
     }
@@ -67,7 +71,7 @@ public class BlockManagerTest {
     @Test
     public void generateAccessions() throws AccessionCouldNotBeGeneratedException {
         BlockManager manager = new BlockManager();
-        manager.addBlock(new ContiguousIdBlock(CATEGORY_ID, INSTANCE_ID, 0, 100));
+        manager.addNewBlock(new ContiguousIdBlock(CATEGORY_ID, INSTANCE_ID, 0, 100));
         long[] accessions = manager.pollNext(10);
         assertEquals(10, accessions.length);
         assertArrayEquals(new long[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, accessions);
@@ -76,7 +80,7 @@ public class BlockManagerTest {
     @Test
     public void generateAccessionsAndRelease() throws AccessionCouldNotBeGeneratedException {
         BlockManager manager = new BlockManager();
-        manager.addBlock(new ContiguousIdBlock(CATEGORY_ID, INSTANCE_ID, 0, 100));
+        manager.addNewBlock(new ContiguousIdBlock(CATEGORY_ID, INSTANCE_ID, 0, 100));
         long[] accessions = manager.pollNext(10);
         assertEquals(10, accessions.length);
         assertArrayEquals(new long[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, accessions);
@@ -89,7 +93,7 @@ public class BlockManagerTest {
     @Test
     public void generateAccessionsAndReleaseSome() throws AccessionCouldNotBeGeneratedException {
         BlockManager manager = new BlockManager();
-        manager.addBlock(new ContiguousIdBlock(CATEGORY_ID, INSTANCE_ID, 0, 100));
+        manager.addNewBlock(new ContiguousIdBlock(CATEGORY_ID, INSTANCE_ID, 0, 100));
         long[] accessions = manager.pollNext(10);
         assertEquals(10, accessions.length);
         assertArrayEquals(new long[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, accessions);
@@ -105,7 +109,7 @@ public class BlockManagerTest {
     @Test
     public void generateAccessionsAndConfirmSome() throws AccessionCouldNotBeGeneratedException {
         BlockManager manager = new BlockManager();
-        manager.addBlock(new ContiguousIdBlock(CATEGORY_ID, INSTANCE_ID, 0, 100));
+        manager.addNewBlock(new ContiguousIdBlock(CATEGORY_ID, INSTANCE_ID, 0, 100));
         long[] accessions = manager.pollNext(10);
         assertEquals(10, accessions.length);
         assertArrayEquals(new long[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, accessions);
@@ -118,7 +122,7 @@ public class BlockManagerTest {
     @Test
     public void recoverState() throws AccessionCouldNotBeGeneratedException {
         BlockManager manager = new BlockManager();
-        manager.addBlock(new ContiguousIdBlock(CATEGORY_ID, INSTANCE_ID, 0, 100));
+        manager.addNewBlock(new ContiguousIdBlock(CATEGORY_ID, INSTANCE_ID, 0, 100));
         manager.recoverState(new long[]{0, 1, 2, 6, 7, 8, 9});
         long[] accessions = manager.pollNext(10);
         assertEquals(3, accessions.length);
@@ -131,8 +135,8 @@ public class BlockManagerTest {
     @Test
     public void multipleContinuousBlocks() throws AccessionCouldNotBeGeneratedException {
         BlockManager manager = new BlockManager();
-        manager.addBlock(new ContiguousIdBlock(CATEGORY_ID, INSTANCE_ID, 0, 10));
-        manager.addBlock(new ContiguousIdBlock(CATEGORY_ID, INSTANCE_ID, 10, 10));
+        manager.addNewBlock(new ContiguousIdBlock(CATEGORY_ID, INSTANCE_ID, 0, 10));
+        manager.addNewBlock(new ContiguousIdBlock(CATEGORY_ID, INSTANCE_ID, 10, 10));
         manager.recoverState(new long[]{0, 1, 2, 6, 7, 8, 9});
         long[] accessions = manager.pollNext(10);
         assertEquals(3, accessions.length);
@@ -145,12 +149,73 @@ public class BlockManagerTest {
     @Test
     public void commitAllValuesOnBlockManager() throws AccessionCouldNotBeGeneratedException {
         BlockManager manager = new BlockManager();
-        manager.addBlock(new ContiguousIdBlock(CATEGORY_ID, INSTANCE_ID, 0, 10));
-        manager.addBlock(new ContiguousIdBlock(CATEGORY_ID, INSTANCE_ID, 10, 10));
+        manager.addNewBlock(new ContiguousIdBlock(CATEGORY_ID, INSTANCE_ID, 0, 10));
+        manager.addNewBlock(new ContiguousIdBlock(CATEGORY_ID, INSTANCE_ID, 10, 10));
         long[] accessions1 = manager.pollNext(10);
         long[] accessions2 = manager.pollNext(10);
         manager.commit(accessions1);
         manager.commit(accessions2);
     }
 
+    @Test
+    public void commitMoreAccessionsThanMaxPerBlock() throws AccessionCouldNotBeGeneratedException {
+        BlockManager manager = new BlockManager();
+        manager.addNewBlock(new ContiguousIdBlock(CATEGORY_ID, INSTANCE_ID, 0, 10));
+        manager.addNewBlock(new ContiguousIdBlock(CATEGORY_ID, INSTANCE_ID, 10, 10));
+        long[] accessions1 = manager.pollNext(10);
+        long[] accessions2 = manager.pollNext(2);
+        long[] all = Arrays.copyOf(accessions1, accessions1.length + accessions2.length);
+        System.arraycopy(accessions2, 0, all, accessions1.length, accessions2.length);
+
+        Set<ContiguousIdBlock> blocksToUpdate = manager.commit(all);
+
+        //Entire first block should be marked as used
+        //Second should only mark 2 accessions as used (accession 10 and 11)
+        assertEquals(2, blocksToUpdate.size());
+        for (ContiguousIdBlock currentBlock : blocksToUpdate) {
+            switch ((int) currentBlock.getFirstValue()) {
+                case 0:
+                    assertEquals(9, currentBlock.getLastCommitted());
+                    break;
+                case 10:
+                    assertEquals(11, currentBlock.getLastCommitted());
+                    break;
+                default:
+            }
+        }
+    }
+
+    @Test
+    public void commitMoreAccessionsThanMaxPerBlock2() throws AccessionCouldNotBeGeneratedException {
+        BlockManager manager = new BlockManager();
+        manager.addNewBlock(new ContiguousIdBlock(CATEGORY_ID, INSTANCE_ID, 0, 10));
+        long[] accessions1 = manager.pollNext(3);
+        Set<ContiguousIdBlock> blocksToUpdate = manager.commit(accessions1);
+
+        assertEquals(1, blocksToUpdate.size());
+        assertEquals(2, blocksToUpdate.iterator().next().getLastCommitted());
+
+        long[] accessions2 = {};
+        Set<ContiguousIdBlock> blocksToUpdate2 = manager.commit(accessions2);
+        assertEquals(1, blocksToUpdate2.size());
+        assertEquals(2, blocksToUpdate2.iterator().next().getLastCommitted());
+
+//        long[] accessions2 = {1, 2, 3};
+//
+//
+//        //Entire first block should be marked as used
+//        //Second should only mark 2 accessions as used (accession 10 and 11)
+//        assertEquals(2, blocksToUpdate.size());
+//        for (ContiguousIdBlock currentBlock : blocksToUpdate) {
+//            switch ((int) currentBlock.getFirstValue()) {
+//                case 0:
+//                    assertEquals(9, currentBlock.getLastCommitted());
+//                    break;
+//                case 10:
+//                    assertEquals(11, currentBlock.getLastCommitted());
+//                    break;
+//                default:
+//            }
+//        }
+    }
 }

--- a/accession-commons-monotonic-generator-jpa/src/test/java/uk/ac/ebi/ampt2d/commons/accession/generators/monotonic/BlockManagerTest.java
+++ b/accession-commons-monotonic-generator-jpa/src/test/java/uk/ac/ebi/ampt2d/commons/accession/generators/monotonic/BlockManagerTest.java
@@ -23,7 +23,6 @@ import uk.ac.ebi.ampt2d.commons.accession.core.exceptions.AccessionIsNotPendingE
 import uk.ac.ebi.ampt2d.commons.accession.persistence.jpa.monotonic.entities.ContiguousIdBlock;
 
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.Set;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -183,39 +182,5 @@ public class BlockManagerTest {
                 default:
             }
         }
-    }
-
-    @Test
-    public void commitMoreAccessionsThanMaxPerBlock2() throws AccessionCouldNotBeGeneratedException {
-        BlockManager manager = new BlockManager();
-        manager.addNewBlock(new ContiguousIdBlock(CATEGORY_ID, INSTANCE_ID, 0, 10));
-        long[] accessions1 = manager.pollNext(3);
-        Set<ContiguousIdBlock> blocksToUpdate = manager.commit(accessions1);
-
-        assertEquals(1, blocksToUpdate.size());
-        assertEquals(2, blocksToUpdate.iterator().next().getLastCommitted());
-
-        long[] accessions2 = {};
-        Set<ContiguousIdBlock> blocksToUpdate2 = manager.commit(accessions2);
-        assertEquals(1, blocksToUpdate2.size());
-        assertEquals(2, blocksToUpdate2.iterator().next().getLastCommitted());
-
-//        long[] accessions2 = {1, 2, 3};
-//
-//
-//        //Entire first block should be marked as used
-//        //Second should only mark 2 accessions as used (accession 10 and 11)
-//        assertEquals(2, blocksToUpdate.size());
-//        for (ContiguousIdBlock currentBlock : blocksToUpdate) {
-//            switch ((int) currentBlock.getFirstValue()) {
-//                case 0:
-//                    assertEquals(9, currentBlock.getLastCommitted());
-//                    break;
-//                case 10:
-//                    assertEquals(11, currentBlock.getLastCommitted());
-//                    break;
-//                default:
-//            }
-//        }
     }
 }

--- a/accession-commons-monotonic-generator-jpa/src/test/java/uk/ac/ebi/ampt2d/commons/accession/generators/monotonic/MonotonicAccessionGeneratorTest.java
+++ b/accession-commons-monotonic-generator-jpa/src/test/java/uk/ac/ebi/ampt2d/commons/accession/generators/monotonic/MonotonicAccessionGeneratorTest.java
@@ -113,7 +113,7 @@ public class MonotonicAccessionGeneratorTest {
         block = repository.findFirstByCategoryIdAndApplicationInstanceIdOrderByLastValueDesc(CATEGORY_ID, INSTANCE_ID);
         assertEquals(0, block.getFirstValue());
         assertEquals(BLOCK_SIZE - 1, block.getLastValue());
-        assertEquals(999, block.getLastCommitted());
+        assertEquals(block.getLastValue(), block.getLastCommitted());
 
         generator2.generateAccessions(TENTH_BLOCK_SIZE);
         assertEquals(2, repository.count());
@@ -172,7 +172,7 @@ public class MonotonicAccessionGeneratorTest {
 
         ContiguousIdBlock block =
                 repository.findFirstByCategoryIdAndApplicationInstanceIdOrderByLastValueDesc(CATEGORY_ID, INSTANCE_ID);
-        assertEquals(999, block.getLastCommitted());
+        assertEquals(block.getLastValue(), block.getLastCommitted());
     }
 
     @Test
@@ -185,7 +185,7 @@ public class MonotonicAccessionGeneratorTest {
 
         ContiguousIdBlock block =
                 repository.findFirstByCategoryIdAndApplicationInstanceIdOrderByLastValueDesc(CATEGORY_ID, INSTANCE_ID);
-        assertEquals(999, block.getLastCommitted());
+        assertEquals(block.getLastValue(), block.getLastCommitted());
 
         generator.commit(accessions1);
 
@@ -320,7 +320,7 @@ public class MonotonicAccessionGeneratorTest {
                 repository.findFirstByCategoryIdAndApplicationInstanceIdOrderByLastValueDesc(CATEGORY_ID, INSTANCE_ID);
 
         //New generated block marked as used
-        assertEquals(999, block.getLastCommitted());
+        assertEquals(block.getLastValue(), block.getLastCommitted());
         //Last block is marked as used and can't be recovered so there are no ranges available
         assertTrue(generatorRecovering.getAvailableRanges().isEmpty());
     }


### PR DESCRIPTION
Mark blocks as used when reserving and releasing unused accessions in the post save (after saving in mongo)